### PR TITLE
fix: Too many arguments for MYSENSORS::DEVICE::mapReading

### DIFF
--- a/fhem/FHEM/10_MYSENSORS_DEVICE.pm
+++ b/fhem/FHEM/10_MYSENSORS_DEVICE.pm
@@ -316,7 +316,7 @@ sub sendClientMessage($%) {
   sendMessage($hash->{IODev},%msg);
 }
 
-sub mapReading($$) {
+sub mapReading($$$$) {
   my($hash, $type, $childId, $value) = @_;
 
   if(defined (my $mapping = $hash->{typeMappings}->{$type})) {


### PR DESCRIPTION
Meine Perl-Version hat die fehlenden $-Zeichen angekreidet. 
