### PR TITLE
provide sketch name and version as readings.

### DIFF
--- a/fhem/FHEM/10_MYSENSORS_DEVICE.pm
+++ b/fhem/FHEM/10_MYSENSORS_DEVICE.pm
@@ -520,10 +520,12 @@ sub onInternalMessage($$) {
     };
     $type == I_SKETCH_NAME and do {
       $hash->{$typeStr} = $msg->{payload};
+      readingsSingleUpdate($hash,"SKETCH_NAME",$msg->{payload},1);
       last;
     };
     $type == I_SKETCH_VERSION and do {
       $hash->{$typeStr} = $msg->{payload};
+      readingsSingleUpdate($hash,"SKETCH_VERSION",$msg->{payload},1);
       last;
     };
     $type == I_REBOOT and do {


### PR DESCRIPTION
Hallo Norbert,
im Forum gab es einen Wunsch, die MySensors-Sketch-Name und -Version als Reading anzubieten, damit diese auch nach dem FHEM-Restart erhalten bleiben (http://forum.fhem.de/index.php/topic,26807.msg352943.html#msg352943).
Würdest Du diesen Patch annehmen und ggf. in FHEM-Repo einchecken? 
Danke und Grüße,
Alexander
